### PR TITLE
Unnecessary list removal

### DIFF
--- a/apps/job_scripts/views.py
+++ b/apps/job_scripts/views.py
@@ -80,7 +80,10 @@ class JobScriptListView(generics.ListCreateAPIView):
             if member.name in supporting_files:
                 match = [x for x in support_files_ouput if member.name in x]
                 contentfobj = tar.extractfile(member)
-                filename = support_files_ouput[match[0]][0]
+                filename = support_files_ouput[match]
+                # List format safeguard
+                if isinstance(filename, list):
+                    filename = filename[0]
                 template_files[filename] = contentfobj.read().decode("utf-8")
 
         # Use tempfile to generate .tar in memory - NOT write to disk

--- a/apps/job_scripts/views.py
+++ b/apps/job_scripts/views.py
@@ -80,7 +80,7 @@ class JobScriptListView(generics.ListCreateAPIView):
             if member.name in supporting_files:
                 match = [x for x in support_files_ouput if member.name in x]
                 contentfobj = tar.extractfile(member)
-                filename = support_files_ouput[match]
+                filename = support_files_ouput[match[0]]
                 # List format safeguard
                 if isinstance(filename, list):
                     filename = filename[0]


### PR DESCRIPTION
Allows a string filename in addition to current format: one-length list of strings. 
Since only first element of the list is checked anyway, this is a straight up simplification for app development.